### PR TITLE
fix: Add Railway deployment configuration files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use official OpenJDK 17 as base image
+FROM openjdk:17-jdk-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy backend files
+COPY backend/ .
+
+# Install Maven
+RUN apt-get update && apt-get install -y maven && rm -rf /var/lib/apt/lists/*
+
+# Build the application
+RUN mvn clean package -DskipTests
+
+# Expose port 8080
+EXPOSE 8080
+
+# Run the application
+CMD ["java", "-jar", "target/ritkart-backend-1.0.0.jar"]

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,15 @@
+[phases.setup]
+nixPkgs = ["maven", "jdk17"]
+
+[phases.build]
+cmds = [
+    "cd backend",
+    "mvn clean package -DskipTests"
+]
+
+[phases.start]
+cmd = "cd backend && java -jar target/ritkart-backend-1.0.0.jar"
+
+[variables]
+NIXPACKS_JDK_VERSION = "17"
+MAVEN_OPTS = "-Xmx1g"


### PR DESCRIPTION
- Add nixpacks.toml to override auto-detection and use maven instead of mvnw
- Add Dockerfile as alternative deployment method
- Both configurations avoid Maven wrapper issues on Railway
- Scout jam: [72385b62-3c1c-4545-bf73-e024ff155237](https://scout.new/jam/72385b62-3c1c-4545-bf73-e024ff155237)