### PR TITLE
fix: Remove spring.profiles.active from application-prod.properties

### DIFF
--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,6 +1,5 @@
 server.port=8080
 server.servlet.context-path=/api
-spring.profiles.active=prod
 
 # Database Configuration
 spring.data.mongodb.uri=mongodb://your-prod-mongodb-uri


### PR DESCRIPTION
## 🔧 **Critical Spring Boot Configuration Fix**

**Issue**: Application failing to start on Render with error:


**Root Cause**: Cannot set  inside the  file itself.

**Solution**: 
- ✅ Removed  from 
- ✅ Profile should be set via environment variable  in Render

**Files Changed**: 

**Testing**: This fix resolves the Spring Boot startup error on Render deployment.

**Deployment Ready**: After merge, Render should deploy successfully with environment variable set.

---

**Urgent fix for production deployment** 🚀

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view jam](https://scout.new/jam/72385b62-3c1c-4545-bf73-e024ff155237))